### PR TITLE
Add left-hand controls

### DIFF
--- a/source/game.d
+++ b/source/game.d
@@ -587,16 +587,16 @@ void drawAnimal(AnimalKind kind, Vec2 position, int frame, DrawOptions options =
 
 bool isLeftPressed() {
     version(WebAssembly) {
-        return Keyboard.j.isPressed || (mouseScreenPosition.x <= gameWidth * 0.5f && Mouse.left.isPressed);
+        return Keyboard.j.isPressed || Keyboard.space.isPressed || (mouseScreenPosition.x <= gameWidth * 0.5f && Mouse.left.isPressed);
     } else {
-        return Keyboard.j.isPressed;
+        return Keyboard.j.isPressed || Keyboard.space.isPressed;
     }
 }
 
 bool isRightPressed() {
     version(WebAssembly) {
-        return Keyboard.k.isPressed || (mouseScreenPosition.x > gameWidth * 0.5f && Mouse.left.isPressed);
+        return Keyboard.k.isPressed || Keyboard.f.isPressed || (mouseScreenPosition.x > gameWidth * 0.5f && Mouse.left.isPressed);
     } else {
-        return Keyboard.k.isPressed;
+        return Keyboard.k.isPressed || Keyboard.f.isPressed;
     }
 }


### PR DESCRIPTION
Current controls (j+k) aren’t nice to input through the left hand on common keyboard layouts.